### PR TITLE
feat: highlight active navigation tab

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,5 @@
 <script src="{{ base_path }}/assets/js/main.min.js"></script>
+<script src="{{ base_path }}/assets/js/active-nav.js"></script>
 
 {% include analytics.html %}
 {% include /comments-providers/scripts.html %}

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -24,3 +24,14 @@
   margin-top: 0 !important;
 }
 
+/* Highlight the current navigation item */
+#site-nav .visible-links a {
+  transition: color 0.2s ease-in-out, border-bottom-color 0.2s ease-in-out;
+}
+
+#site-nav .visible-links a.active {
+  font-weight: bold;
+  color: $primary-color;
+  border-bottom: 0.25rem solid $primary-color;
+}
+

--- a/assets/js/active-nav.js
+++ b/assets/js/active-nav.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var navLinks = document.querySelectorAll('#site-nav .visible-links a');
+  var currentPath = window.location.pathname.replace(/\/$/, '');
+
+  // If we're on the homepage, do nothing
+  if (currentPath === '' || currentPath === '/') {
+    return;
+  }
+
+  navLinks.forEach(function (link) {
+    var linkPath = link.getAttribute('href').replace(/\/$/, '');
+    if (linkPath !== '' && linkPath !== '/' && currentPath.startsWith(linkPath)) {
+      link.classList.add('active');
+      link.setAttribute('aria-current', 'page');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add vanilla JavaScript to mark the current page's navigation link as active
- style active top navigation link for visual emphasis
- load new script alongside existing site scripts

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Installing nokogiri 1.10.10 with native extensions; stream closed in another thread)*

------
https://chatgpt.com/codex/tasks/task_e_68903eb49c94832b9fac9520f2274568