### PR TITLE
Add portfolio items and card layout

### DIFF
--- a/_pages/portfolio.html
+++ b/_pages/portfolio.html
@@ -7,8 +7,15 @@ author_profile: true
 
 {% include base_path %}
 
-
-{% for post in site.portfolio %}
-  {% include archive-single.html %}
-{% endfor %}
-
+<div class="portfolio-grid">
+  {% for item in site.portfolio %}
+    <div class="portfolio-card">
+      <h3>{{ item.title }}</h3>
+      <p>{{ item.excerpt }}</p>
+      <p><strong>Tech:</strong> {{ item.tech }}</p>
+      <p>
+        <a href="{{ item.github }}">GitHub</a>{% if item.demo %} | <a href="{{ item.demo }}">Demo</a>{% endif %}
+      </p>
+    </div>
+  {% endfor %}
+</div>

--- a/_portfolio/matrix-factorization.md
+++ b/_portfolio/matrix-factorization.md
@@ -1,0 +1,8 @@
+---
+title: "Matrix Factorization for Recommender Systems"
+excerpt: "Python implementation of matrix factorization techniques to build recommendation engines."
+tech: "Python"
+github: https://github.com/AnwarXahid/Matrix-Factorization-for-Recommender-System
+demo: ""
+collection: portfolio
+---

--- a/_portfolio/othello-agent.md
+++ b/_portfolio/othello-agent.md
@@ -1,0 +1,8 @@
+---
+title: "Othello Agent"
+excerpt: "AI agent that plays the Othello board game using search-based strategies."
+tech: "Java"
+github: https://github.com/AnwarXahid/Othello-Agent
+demo: ""
+collection: portfolio
+---

--- a/_portfolio/portfolio-1.md
+++ b/_portfolio/portfolio-1.md
@@ -1,7 +1,0 @@
----
-title: "Portfolio item number 1"
-excerpt: "Short description of portfolio item number 1<br/><img src='/images/500x300.png'>"
-collection: portfolio
----
-
-This is an item in your portfolio. It can be have images or nice text. If you name the file .md, it will be parsed as markdown. If you name the file .html, it will be parsed as HTML. 

--- a/_portfolio/portfolio-2.html
+++ b/_portfolio/portfolio-2.html
@@ -1,7 +1,0 @@
----
-title: "Portfolio item number 2"
-excerpt: "Short description of portfolio item number 2 <br/><img src='/images/500x300.png'>"
-collection: portfolio
----
-
-This is an item in your portfolio. It can be have images or nice text. If you name the file .md, it will be parsed as markdown. If you name the file .html, it will be parsed as HTML. 

--- a/_portfolio/ray-tracing.md
+++ b/_portfolio/ray-tracing.md
@@ -1,0 +1,8 @@
+---
+title: "Ray Tracing"
+excerpt: "Simple C++ ray tracer capable of rendering basic 3D scenes."
+tech: "C++, C"
+github: https://github.com/AnwarXahid/Ray-Tracing
+demo: ""
+collection: portfolio
+---

--- a/_portfolio/simplest-messenger.md
+++ b/_portfolio/simplest-messenger.md
@@ -1,0 +1,8 @@
+---
+title: "Simplest Messenger"
+excerpt: "Lightweight Java messaging application demonstrating client-server communication."
+tech: "Java"
+github: https://github.com/AnwarXahid/Simplest-Messenger
+demo: ""
+collection: portfolio
+---

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -77,3 +77,21 @@ a {
   margin-top: 0 !important;
 }
 
+
+/* Portfolio cards */
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: $spacing-unit;
+}
+
+.portfolio-card {
+  border: 1px solid lighten($brand-color, 40%);
+  padding: $spacing-unit;
+  border-radius: 0.5rem;
+  background-color: #fff;
+}
+
+.portfolio-card h3 {
+  margin-top: 0;
+}


### PR DESCRIPTION
## Summary
- add portfolio entries for multiple GitHub projects
- display portfolio items as cards on the portfolio page
- style portfolio cards with a responsive grid

## Testing
- `bundle install` *(fails: Failed to build gem native extension for nokogiri)*
- `bundle exec jekyll build` *(not run due to previous failure)*

------
https://chatgpt.com/codex/tasks/task_e_689334b27b60832bb96e0b181e3664b1