### PR TITLE
Add blog section and metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ title                    : "Anwar Hossain Zahid"
 title_separator          : "-"
 name                     : &name "Anwar Hossain Zahid"
 description              : &description "Phd Aspirant in Computer Science"
+keywords                 : "machine learning, debugging, software engineering, blog"
 url                      : https://anwarxahid.github.io # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
 baseurl                  : "" # the subpath of your site, e.g. "/blog"
 repository               : "anwarxahid/anwarxahid.github.io"
@@ -57,7 +58,7 @@ yandex_site_verification :
 
 # Social Sharing
 twitter:
-  username               : &twitter
+  username               : &twitter anwarxahid
 facebook:
   username               :
   app_id                 :
@@ -81,8 +82,8 @@ analytics:
 # Site Author
 author:
   name             : "Anwar Zahid"
-    avatar           : "profile.jpg"
-    bio              : "Ph.D. Student | ML Model Debugging | Software Engineer | Researcher"
+  avatar           : "profile.jpg"
+  bio              : "Ph.D. Student | ML Model Debugging | Software Engineer | Researcher"
   location         : "Ames, Iowa"
   employer         :
   pubmed           :
@@ -96,7 +97,7 @@ author:
   flickr           :
   facebook         : "S201305119/"
   foursquare       :
-  github           :
+  github           : "anwarxahid"
   google_plus      :
   keybase          :
   instagram        :
@@ -109,7 +110,7 @@ author:
   stackoverflow    : # http://stackoverflow.com/users/123456/username
   steam            :
   tumblr           :
-  twitter          :
+  twitter          : "anwarxahid"
   vine             :
   weibo            :
   xing             :

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,6 +6,6 @@ main:
   - title: "Projects"
     url: /portfolio/
   - title: "Blog"
-    url: /year-archive/
+    url: /blog/
   - title: "Resume"
     url: /files/resume.pdf

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,3 +19,9 @@
 <link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
+
+{% if site.keywords %}
+<meta name="keywords" content="{{ site.keywords }}">
+{% endif %}
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,6 +8,9 @@ redirect_from:
   - /about.html
 ---
 
+[![GitHub Repo](https://img.shields.io/github/stars/anwarxahid/anwarxahid.github.io?style=social)](https://github.com/anwarxahid/anwarxahid.github.io)
+[![GitHub license](https://img.shields.io/github/license/anwarxahid/anwarxahid.github.io)](https://github.com/anwarxahid/anwarxahid.github.io/blob/master/LICENSE)
+
 ## <span style="color:#2F4F4F;">About Me</span>
 
 I'm **<span style="color:#4682B4;">Anwar Hossain Zahid</span>**, a **Ph.D. candidate in Computer Science at Iowa State University**, advised by [<span style="color:#8B0000;">Professor Wei Le</span>](https://weile.work/).

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -1,0 +1,9 @@
+---
+layout: posts
+title: "Blog"
+permalink: /blog/
+author_profile: true
+---
+
+Welcome to the blog archive.
+

--- a/_posts/2025-01-01-detecting-bugs-in-ml-models.md
+++ b/_posts/2025-01-01-detecting-bugs-in-ml-models.md
@@ -1,0 +1,9 @@
+---
+layout: single
+title: "Detecting Bugs in ML Models"
+date: 2025-01-01
+categories: blog
+---
+
+Emerging tools help surface hidden defects in machine learning systems, improving reliability and trustworthiness.
+

--- a/_posts/2025-02-01-differential-debugging-for-llms.md
+++ b/_posts/2025-02-01-differential-debugging-for-llms.md
@@ -1,0 +1,9 @@
+---
+layout: single
+title: "Differential Debugging for LLMs"
+date: 2025-02-01
+categories: blog
+---
+
+Differential techniques compare language model versions to pinpoint regressions and guide targeted fixes.
+


### PR DESCRIPTION
## Summary
- add blog index page and two example posts
- expose blog in site navigation and enhance site metadata
- add repository badges and extra meta tags

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Nokogiri compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_689337ba2c30832b975b7b4b9f9928fc