### PR TITLE
Rename About navigation entry to Summary

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,5 +1,5 @@
 main:
-  - title: "About"
+  - title: "Summary"
     url: /about-me/
   - title: "Research"
     url: /research/


### PR DESCRIPTION
## Summary
- rename About nav item to Summary while retaining /about-me/

## Testing
- `npm test` (fails: Missing script "test")
- `bundle exec jekyll build` (fails: bundler: command not found: jekyll)
- `bundle install` (attempted; jekyll still missing)


------
https://chatgpt.com/codex/tasks/task_e_6893fed1ff74832bb8ee66d4a092be33