### PR TITLE
Enable post likes and configure comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,9 +22,9 @@ future                   : true
 read_more                : "disabled" # if enabled, adds "Read more" links to excerpts
 talkmap_link             : false #change to true to add link to talkmap on talks page
 comments:
-  provider               : # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
+  provider               : "disqus" # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
   disqus:
-    shortname            :
+    shortname            : "example"
   discourse:
     server               : # https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963 , e.g.: meta.discourse.org
   facebook:

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -67,10 +67,12 @@ layout: default
       {% if page.share %}{% include social-share.html %}{% endif %}
 
       {% include post_pagination.html %}
-<!--      <div class="like-container">-->
-<!--        <button id="like-button">Like</button>-->
-<!--        <span id="like-count">0</span>-->
-<!--      </div>-->
+      {% if page.collection == 'posts' %}
+      <div class="like-container">
+        <button id="like-button">Like</button>
+        <span id="like-count">0</span>
+      </div>
+      {% endif %}
     </div>
 
     {% if site.comments.provider and page.comments %}

--- a/_posts/2025-05-01-second-post.md
+++ b/_posts/2025-05-01-second-post.md
@@ -1,0 +1,8 @@
+---
+layout: single
+title: "A Second Post"
+categories: blog
+comments: true
+---
+
+This is the second post used to demonstrate pagination.


### PR DESCRIPTION
## Summary
- show like button only on posts
- configure Disqus comments
- add another post for pagination

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: nokogiri build error)*
- `JEKYLL_NO_BUNDLER_REQUIRE=true jekyll build` *(fails: undefined method `tainted?` for String)*

------
https://chatgpt.com/codex/tasks/task_e_6895c4623fb4832b8d5492abd697ab6a