### PR TITLE
Enable Staticman comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ future                   : true
 read_more                : "disabled" # if enabled, adds "Read more" links to excerpts
 talkmap_link             : false #change to true to add link to talkmap on talks page
 comments:
-  provider               : "disqus" # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
+  provider               : "staticman" # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
   disqus:
     shortname            : "example"
   discourse:
@@ -33,7 +33,7 @@ comments:
     colorscheme          : # "light" (default), "dark"
 staticman:
   allowedFields          : ['name', 'email', 'url', 'message']
-  branch                 : "gh-pages" # "master", "gh-pages"
+  branch                 : "master" # branch where comments are stored
   commitMessage          : "New comment."
   filename               : comment-{@timestamp}
   format                 : "yml"

--- a/_data/comments/second-post/comment-0000000000000.yml
+++ b/_data/comments/second-post/comment-0000000000000.yml
@@ -1,0 +1,6 @@
+message: "Excited to read more!"
+name: Test User
+email: 55502f40dc8b7c769880b10874abc9d0
+url: 'https://example.com'
+hidden: ''
+date: '2025-05-01T00:00:00Z'


### PR DESCRIPTION
## Summary
- switch comment provider to Staticman and point to master branch
- add example comment entry for `second-post`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: An error occurred while installing nokogiri)*

------
https://chatgpt.com/codex/tasks/task_e_6895cad4e440832b9542ab52cbbe5d1c